### PR TITLE
feat: implement profile screen with navigation system - Younes

### DIFF
--- a/app/src/main/java/com/swent/skillswap/TestProfileActivity.kt
+++ b/app/src/main/java/com/swent/skillswap/TestProfileActivity.kt
@@ -33,4 +33,3 @@ class TestProfileActivity : ComponentActivity() {
 fun ProfileScreenPreview() {
     SkillSwapAppTheme { ProfileMainScreen() }
 }
-

--- a/app/src/main/java/com/swent/skillswap/ui/profile/AccountReviewScreen.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/profile/AccountReviewScreen.kt
@@ -18,9 +18,7 @@ import androidx.compose.ui.unit.sp
 @Composable
 fun AccountReviewScreen(onBackClick: () -> Unit) {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
+        modifier = Modifier.fillMaxSize().padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // Title
@@ -35,26 +33,20 @@ fun AccountReviewScreen(onBackClick: () -> Unit) {
         // Back button
         Button(
             onClick = onBackClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color.Transparent
-            ),
+            modifier = Modifier.fillMaxWidth().height(48.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
             shape = RoundedCornerShape(8.dp)
         ) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        brush = Brush.horizontalGradient(
-                            colors = listOf(
-                                Color(0xFF0F3F66),
-                                Color(0xFF1E7ECC)
-                            )
+                modifier =
+                    Modifier.fillMaxSize()
+                        .background(
+                            brush =
+                                Brush.horizontalGradient(
+                                    colors = listOf(Color(0xFF0F3F66), Color(0xFF1E7ECC))
+                                )
                         )
-                    )
-                    .clip(RoundedCornerShape(8.dp)),
+                        .clip(RoundedCornerShape(8.dp)),
                 contentAlignment = Alignment.Center
             ) {
                 Text(

--- a/app/src/main/java/com/swent/skillswap/ui/profile/AccountScreen.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/profile/AccountScreen.kt
@@ -18,9 +18,7 @@ import androidx.compose.ui.unit.sp
 @Composable
 fun AccountScreen(onBackClick: () -> Unit) {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
+        modifier = Modifier.fillMaxSize().padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // Title
@@ -35,26 +33,20 @@ fun AccountScreen(onBackClick: () -> Unit) {
         // Back button
         Button(
             onClick = onBackClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color.Transparent
-            ),
+            modifier = Modifier.fillMaxWidth().height(48.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
             shape = RoundedCornerShape(8.dp)
         ) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        brush = Brush.horizontalGradient(
-                            colors = listOf(
-                                Color(0xFF0F3F66),
-                                Color(0xFF1E7ECC)
-                            )
+                modifier =
+                    Modifier.fillMaxSize()
+                        .background(
+                            brush =
+                                Brush.horizontalGradient(
+                                    colors = listOf(Color(0xFF0F3F66), Color(0xFF1E7ECC))
+                                )
                         )
-                    )
-                    .clip(RoundedCornerShape(8.dp)),
+                        .clip(RoundedCornerShape(8.dp)),
                 contentAlignment = Alignment.Center
             ) {
                 Text(

--- a/app/src/main/java/com/swent/skillswap/ui/profile/AddAccountsScreen.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/profile/AddAccountsScreen.kt
@@ -18,9 +18,7 @@ import androidx.compose.ui.unit.sp
 @Composable
 fun AddAccountsScreen(onBackClick: () -> Unit) {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
+        modifier = Modifier.fillMaxSize().padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // Title
@@ -35,26 +33,20 @@ fun AddAccountsScreen(onBackClick: () -> Unit) {
         // Back button
         Button(
             onClick = onBackClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color.Transparent
-            ),
+            modifier = Modifier.fillMaxWidth().height(48.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
             shape = RoundedCornerShape(8.dp)
         ) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        brush = Brush.horizontalGradient(
-                            colors = listOf(
-                                Color(0xFF0F3F66),
-                                Color(0xFF1E7ECC)
-                            )
+                modifier =
+                    Modifier.fillMaxSize()
+                        .background(
+                            brush =
+                                Brush.horizontalGradient(
+                                    colors = listOf(Color(0xFF0F3F66), Color(0xFF1E7ECC))
+                                )
                         )
-                    )
-                    .clip(RoundedCornerShape(8.dp)),
+                        .clip(RoundedCornerShape(8.dp)),
                 contentAlignment = Alignment.Center
             ) {
                 Text(

--- a/app/src/main/java/com/swent/skillswap/ui/profile/InformationScreen.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/profile/InformationScreen.kt
@@ -18,9 +18,7 @@ import androidx.compose.ui.unit.sp
 @Composable
 fun InformationScreen(onBackClick: () -> Unit) {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
+        modifier = Modifier.fillMaxSize().padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // Title
@@ -35,26 +33,20 @@ fun InformationScreen(onBackClick: () -> Unit) {
         // Back button
         Button(
             onClick = onBackClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color.Transparent
-            ),
+            modifier = Modifier.fillMaxWidth().height(48.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
             shape = RoundedCornerShape(8.dp)
         ) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        brush = Brush.horizontalGradient(
-                            colors = listOf(
-                                Color(0xFF0F3F66),
-                                Color(0xFF1E7ECC)
-                            )
+                modifier =
+                    Modifier.fillMaxSize()
+                        .background(
+                            brush =
+                                Brush.horizontalGradient(
+                                    colors = listOf(Color(0xFF0F3F66), Color(0xFF1E7ECC))
+                                )
                         )
-                    )
-                    .clip(RoundedCornerShape(8.dp)),
+                        .clip(RoundedCornerShape(8.dp)),
                 contentAlignment = Alignment.Center
             ) {
                 Text(

--- a/app/src/main/java/com/swent/skillswap/ui/profile/MySkillsScreen.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/profile/MySkillsScreen.kt
@@ -18,9 +18,7 @@ import androidx.compose.ui.unit.sp
 @Composable
 fun MySkillsScreen(onBackClick: () -> Unit) {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
+        modifier = Modifier.fillMaxSize().padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // Title
@@ -35,26 +33,20 @@ fun MySkillsScreen(onBackClick: () -> Unit) {
         // Back button
         Button(
             onClick = onBackClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color.Transparent
-            ),
+            modifier = Modifier.fillMaxWidth().height(48.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
             shape = RoundedCornerShape(8.dp)
         ) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        brush = Brush.horizontalGradient(
-                            colors = listOf(
-                                Color(0xFF0F3F66),
-                                Color(0xFF1E7ECC)
-                            )
+                modifier =
+                    Modifier.fillMaxSize()
+                        .background(
+                            brush =
+                                Brush.horizontalGradient(
+                                    colors = listOf(Color(0xFF0F3F66), Color(0xFF1E7ECC))
+                                )
                         )
-                    )
-                    .clip(RoundedCornerShape(8.dp)),
+                        .clip(RoundedCornerShape(8.dp)),
                 contentAlignment = Alignment.Center
             ) {
                 Text(

--- a/app/src/main/java/com/swent/skillswap/ui/profile/ProfileMainScreen.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/profile/ProfileMainScreen.kt
@@ -1,7 +1,6 @@
 package com.swent.skillswap.ui.profile
 
 import androidx.compose.runtime.*
-import androidx.compose.ui.Modifier
 
 enum class ProfileScreenType {
     MAIN,

--- a/app/src/main/java/com/swent/skillswap/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/profile/ProfileScreen.kt
@@ -1,23 +1,24 @@
 package com.swent.skillswap.ui.profile
+
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.runtime.remember
 
 @Composable
 fun ProfileScreen(
@@ -58,23 +59,19 @@ fun ProfileScreen(
                     text = "My skills",
                     fontSize = 14.sp,
                     color = Color.White,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null
-                        ) {
-                            onMySkillsClick()
-                        }
-                        .padding(vertical = 12.dp)
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                onMySkillsClick()
+                            }
+                            .padding(vertical = 12.dp)
                 )
 
                 // Horizontal white line
-                Canvas(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(1.dp)
-                ) {
+                Canvas(modifier = Modifier.fillMaxWidth().height(1.dp)) {
                     drawLine(
                         color = Color.White,
                         start = androidx.compose.ui.geometry.Offset(0f, 0f),
@@ -89,23 +86,19 @@ fun ProfileScreen(
                     text = "Your informations and permissions",
                     fontSize = 14.sp,
                     color = Color.White,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null
-                        ) {
-                            onInformationClick()
-                        }
-                        .padding(vertical = 12.dp)
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                onInformationClick()
+                            }
+                            .padding(vertical = 12.dp)
                 )
 
                 // Horizontal white line
-                Canvas(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(1.dp)
-                ) {
+                Canvas(modifier = Modifier.fillMaxWidth().height(1.dp)) {
                     drawLine(
                         color = Color.White,
                         start = androidx.compose.ui.geometry.Offset(0f, 0f),
@@ -120,15 +113,15 @@ fun ProfileScreen(
                     text = "Password and security",
                     fontSize = 14.sp,
                     color = Color.White,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null
-                        ) {
-                            onSecurityClick()
-                        }
-                        .padding(vertical = 12.dp)
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                onSecurityClick()
+                            }
+                            .padding(vertical = 12.dp)
                 )
             }
         }
@@ -151,28 +144,23 @@ fun ProfileScreen(
                 // Account section with emoticon and text (clickable)
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null
-                        ) {
-                            onAccountClick()
-                        }
-                        .padding(vertical = 8.dp)
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                onAccountClick()
+                            }
+                            .padding(vertical = 8.dp)
                 ) {
                     // Emoticon (using a simple circle as emoticon)
-                    Canvas(
-                        modifier = Modifier.size(20.dp)
-                    ) {
-                        drawCircle(
-                            color = Color.White,
-                            radius = 8.dp.toPx()
-                        )
+                    Canvas(modifier = Modifier.size(20.dp)) {
+                        drawCircle(color = Color.White, radius = 8.dp.toPx())
                     }
-                    
+
                     Spacer(modifier = Modifier.width(8.dp))
-                    
+
                     // Account text
                     Text(
                         text = "Account",
@@ -187,23 +175,19 @@ fun ProfileScreen(
                     text = "Review and update your accounts",
                     fontSize = 14.sp,
                     color = Color.White,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null
-                        ) {
-                            onAccountReviewClick()
-                        }
-                        .padding(start = 28.dp, bottom = 12.dp)
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                onAccountReviewClick()
+                            }
+                            .padding(start = 28.dp, bottom = 12.dp)
                 )
 
                 // Horizontal white line
-                Canvas(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(1.dp)
-                ) {
+                Canvas(modifier = Modifier.fillMaxWidth().height(1.dp)) {
                     drawLine(
                         color = Color.White,
                         start = androidx.compose.ui.geometry.Offset(0f, 0f),
@@ -220,15 +204,15 @@ fun ProfileScreen(
                     text = "Add more accounts",
                     fontSize = 14.sp,
                     color = Color.White,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null
-                        ) {
-                            onAddAccountsClick()
-                        }
-                        .padding(vertical = 12.dp)
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
+                                onAddAccountsClick()
+                            }
+                            .padding(vertical = 12.dp)
                 )
             }
         }

--- a/app/src/main/java/com/swent/skillswap/ui/profile/SecurityScreen.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/profile/SecurityScreen.kt
@@ -18,9 +18,7 @@ import androidx.compose.ui.unit.sp
 @Composable
 fun SecurityScreen(onBackClick: () -> Unit) {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
+        modifier = Modifier.fillMaxSize().padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // Title
@@ -35,26 +33,20 @@ fun SecurityScreen(onBackClick: () -> Unit) {
         // Back button
         Button(
             onClick = onBackClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(48.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color.Transparent
-            ),
+            modifier = Modifier.fillMaxWidth().height(48.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
             shape = RoundedCornerShape(8.dp)
         ) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        brush = Brush.horizontalGradient(
-                            colors = listOf(
-                                Color(0xFF0F3F66),
-                                Color(0xFF1E7ECC)
-                            )
+                modifier =
+                    Modifier.fillMaxSize()
+                        .background(
+                            brush =
+                                Brush.horizontalGradient(
+                                    colors = listOf(Color(0xFF0F3F66), Color(0xFF1E7ECC))
+                                )
                         )
-                    )
-                    .clip(RoundedCornerShape(8.dp)),
+                        .clip(RoundedCornerShape(8.dp)),
                 contentAlignment = Alignment.Center
             ) {
                 Text(


### PR DESCRIPTION
All code by Younes, moving files to a PR

- Add ProfileScreen with gradient rectangles and menu items
- Create individual profile pages (MySkills, Information, Security, Account, etc.)
- Implement ProfileMainScreen for navigation state management
- Add gradient back buttons with horizontal gradient styling
- Include horizontal divider lines between menu items
- Support full navigation flow between profile sections
- Add TestProfileActivity for testing profile functionality

Features:
- Two gradient rectangles (black to #2B5080) with 16dp border radius
- Clickable menu items with proper touch targets
- Navigation to 6 different profile pages
- Gradient back buttons (#0F3F66 to #1E7ECC) with white text
- Responsive layout with proper spacing and alignment
- Clean separation between UI and navigation logic