### PR TITLE
feat: add basic workflow to check artifact creation on github

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,53 @@
+name: Build APK
+
+on:
+  push:
+    branches:
+      - M1
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+            
+
+      - name: Decode secrets
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+        run: |
+          if [ -n "$GOOGLE_SERVICES" ]; then
+            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          fi
+
+      - name: Build APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the process of building an Android APK whenever there is a push to the `M1` branch or when manually triggered. This workflow streamlines the build and artifact upload process, making it easier to generate and distribute debug APKs.

**CI/CD automation:**

* Added a new workflow file `.github/workflows/build-apk.yml` to automate building the APK on pushes to the `M1` branch and on manual workflow dispatch.
* Configured the workflow to set up JDK 17, cache Gradle dependencies, and grant execute permission to `gradlew` for consistent build environments.

**Secrets and artifact handling:**

* Decodes the `GOOGLE_SERVICES` secret and writes it to `./app/google-services.json` during the build process.
* Uploads the generated debug APK as a workflow artifact for easy retrieval after the build completes.