### PR TITLE
Feature/location filtering

### DIFF
--- a/app/src/androidTest/java/com/swent/skillswap/UserFirestore/UserFireStoreTest.kt
+++ b/app/src/androidTest/java/com/swent/skillswap/UserFirestore/UserFireStoreTest.kt
@@ -9,14 +9,15 @@ package com.swent.skillswap.UserFirestore
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.firestore.FirebaseFirestore
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.tags.SkillTag
 import com.swent.skillswap.model.user.Preference
 import com.swent.skillswap.model.user.Skill
 import com.swent.skillswap.model.user.User
 import com.swent.skillswap.model.user.UserRepoFirestore
 import com.swent.skillswap.utils.FirebaseEmulator
-import kotlin.text.get
+import java.time.DayOfWeek
+import java.time.LocalTime
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 import org.junit.Assert.*
@@ -32,11 +33,10 @@ class UserFireStoreTest {
 
     init {
         FirebaseEmulator.startEmulator()
-        db = FirebaseEmulator.firestore // get the firestore instance pointing to the emulator
-        repo = UserRepoFirestore(db) // initialize the repository
+        db = FirebaseEmulator.firestore
+        repo = UserRepoFirestore(db)
     }
 
-    // Nettoie la collection users avant chaque test
     @Before
     fun setUp() = runBlocking {
         val users = FirebaseEmulator.firestore.collection("users").get().await()
@@ -45,25 +45,58 @@ class UserFireStoreTest {
         }
     }
 
+    // Helper functions
+    private fun createAvailability(
+        day: DayOfWeek,
+        startHour: Int,
+        startMin: Int,
+        endHour: Int,
+        endMin: Int
+    ) =
+        com.swent.skillswap.model.user.Availability(
+            day = day,
+            startTime = LocalTime.of(startHour, startMin),
+            endTime = LocalTime.of(endHour, endMin)
+        )
+
+    private fun createSkill(name: SkillTag, rank: Float, description: String) =
+        Skill(name = name, rank = rank, description = description)
+
+    private fun createUser(
+        uid: String,
+        username: String,
+        email: String,
+        profilePicture: String = "",
+        skillSet: Set<Skill> = setOf(),
+        rating: Float = 5.0f,
+        availability: List<com.swent.skillswap.model.user.Availability> = listOf(),
+        preference: Preference = Preference.SKILLS,
+        location: GeoPoint = GeoPoint(0.0, 0.0)
+    ) =
+        User(
+            uid = uid,
+            username = username,
+            email = email,
+            profilePicture = profilePicture,
+            skillSet = skillSet,
+            rating = rating,
+            availability = availability,
+            preference = preference,
+            location = location
+        )
+
     @Test
     fun addAndRetrieveUserwithemptySkillAndAvaibility() = runBlocking {
         val uid = repo.getNewUid()
         val user =
-            User(
+            createUser(
                 uid = uid,
                 username = "testuser",
                 email = "test@example.com",
-                profilePicture = "",
-                skillSet = setOf(),
-                rating = 5.0f,
-                availability = listOf(),
-                preference = Preference.SKILLS,
-                location = Location(0.0, 0.0, "test_location")
+                location = GeoPoint(0.0, 0.0)
             )
 
-        // Ajout de l'utilisateur
         repo.addUser(user)
-        // Récupération de l'utilisateur
         val retrievedUser = repo.getUser(uid)
 
         assertNotNull(retrievedUser)
@@ -79,44 +112,26 @@ class UserFireStoreTest {
 
     @Test
     fun addAndRetrieveUserwithSkillAndAvaibility() = runBlocking {
-        val skill1 =
-            Skill(
-                name = SkillTag.COMPUTER_PROGRAMMING,
-                rank = 4.5f,
-                description = "I love programming"
-            )
-        val skill2 = Skill(name = SkillTag.DATABASES, rank = 3.0f, description = "database is ez")
+        val skill1 = createSkill(SkillTag.COMPUTER_PROGRAMMING, 4.5f, "I love programming")
+        val skill2 = createSkill(SkillTag.DATABASES, 3.0f, "database is ez")
 
-        val availability1 =
-            com.swent.skillswap.model.user.Availability(
-                day = java.time.DayOfWeek.MONDAY,
-                startTime = java.time.LocalTime.of(9, 0),
-                endTime = java.time.LocalTime.of(11, 0)
-            )
-        val availability2 =
-            com.swent.skillswap.model.user.Availability(
-                day = java.time.DayOfWeek.WEDNESDAY,
-                startTime = java.time.LocalTime.of(14, 0),
-                endTime = java.time.LocalTime.of(16, 0)
-            )
+        val availability1 = createAvailability(DayOfWeek.MONDAY, 9, 0, 11, 0)
+        val availability2 = createAvailability(DayOfWeek.WEDNESDAY, 14, 0, 16, 0)
 
         val uid = repo.getNewUid()
         val user =
-            User(
+            createUser(
                 uid = uid,
                 username = "testuser2",
                 email = "endenejnd@mdek.ch",
-                profilePicture = "",
                 skillSet = setOf(skill1, skill2),
                 rating = 4.0f,
                 availability = listOf(availability1, availability2),
                 preference = Preference.MONEY,
-                location = Location(46.5191, 6.5668, "EPFL")
+                location = GeoPoint(46.5191, 6.5668)
             )
 
-        // add user in firestore
         repo.addUser(user)
-
         assertEquals(user, repo.getUser(uid))
     }
 
@@ -124,46 +139,24 @@ class UserFireStoreTest {
     fun editUser() = runBlocking {
         val uid = repo.getNewUid()
         val basicUser =
-            User(
+            createUser(
                 uid = uid,
                 username = "testuser",
                 email = "test@example.com",
-                profilePicture = "",
-                skillSet = setOf(),
-                rating = 5.0f,
-                availability = listOf(),
-                preference = Preference.SKILLS,
-                location = Location(0.0, 0.0, "initial_location")
+                location = GeoPoint(0.0, 0.0)
             )
 
-        // add the basic user
         repo.addUser(basicUser)
         assertEquals(basicUser, repo.getUser(uid))
 
-        // the edited user
-        val skill1 =
-            Skill(
-                name = SkillTag.COMPUTER_PROGRAMMING,
-                rank = 4.5f,
-                description = "I love programming"
-            )
-        val skill2 = Skill(name = SkillTag.DATABASES, rank = 3.0f, description = "database is ez")
+        val skill1 = createSkill(SkillTag.COMPUTER_PROGRAMMING, 4.5f, "I love programming")
+        val skill2 = createSkill(SkillTag.DATABASES, 3.0f, "database is ez")
 
-        val availability1 =
-            com.swent.skillswap.model.user.Availability(
-                day = java.time.DayOfWeek.MONDAY,
-                startTime = java.time.LocalTime.of(9, 0),
-                endTime = java.time.LocalTime.of(11, 0)
-            )
-        val availability2 =
-            com.swent.skillswap.model.user.Availability(
-                day = java.time.DayOfWeek.WEDNESDAY,
-                startTime = java.time.LocalTime.of(14, 0),
-                endTime = java.time.LocalTime.of(16, 0)
-            )
+        val availability1 = createAvailability(DayOfWeek.MONDAY, 9, 0, 11, 0)
+        val availability2 = createAvailability(DayOfWeek.WEDNESDAY, 14, 0, 16, 0)
 
         val editedUser =
-            User(
+            createUser(
                 uid = uid,
                 username = "testuser2",
                 email = "endenejnd@mdek.ch",
@@ -172,7 +165,7 @@ class UserFireStoreTest {
                 rating = 4.0f,
                 availability = listOf(availability1, availability2),
                 preference = Preference.MONEY,
-                location = Location(48.8566, 2.3522, "Paris")
+                location = GeoPoint(48.8566, 2.3522)
             )
 
         repo.editUser(basicUser.uid, editedUser)
@@ -181,46 +174,24 @@ class UserFireStoreTest {
 
     @Test
     fun deleteSingleUserFromMultiple() = runBlocking {
-        // User 1
         val uid1 = repo.getNewUid()
         val user1 =
-            User(
+            createUser(
                 uid = uid1,
                 username = "testuser",
                 email = "j'ailadalle@gmail.com",
-                profilePicture = "",
-                skillSet = setOf(),
-                rating = 5.0f,
-                availability = listOf(),
-                preference = Preference.SKILLS,
-                location = Location(40.7128, -74.0060, "New York")
+                location = GeoPoint(40.7128, -74.0060)
             )
 
-        // User 2
-        val skill1 =
-            Skill(
-                name = SkillTag.COMPUTER_PROGRAMMING,
-                rank = 4.5f,
-                description = "I love programming"
-            )
-        val skill2 = Skill(name = SkillTag.DATABASES, rank = 3.0f, description = "database is ez")
+        val skill1 = createSkill(SkillTag.COMPUTER_PROGRAMMING, 4.5f, "I love programming")
+        val skill2 = createSkill(SkillTag.DATABASES, 3.0f, "database is ez")
 
-        val availability1 =
-            com.swent.skillswap.model.user.Availability(
-                day = java.time.DayOfWeek.MONDAY,
-                startTime = java.time.LocalTime.of(9, 0),
-                endTime = java.time.LocalTime.of(11, 0)
-            )
-        val availability2 =
-            com.swent.skillswap.model.user.Availability(
-                day = java.time.DayOfWeek.WEDNESDAY,
-                startTime = java.time.LocalTime.of(14, 0),
-                endTime = java.time.LocalTime.of(16, 0)
-            )
+        val availability1 = createAvailability(DayOfWeek.MONDAY, 9, 0, 11, 0)
+        val availability2 = createAvailability(DayOfWeek.WEDNESDAY, 14, 0, 16, 0)
 
         val uid2 = repo.getNewUid()
         val user2 =
-            User(
+            createUser(
                 uid = uid2,
                 username = "testuser2",
                 email = "endenejnd@mdek.ch",
@@ -229,43 +200,34 @@ class UserFireStoreTest {
                 rating = 4.0f,
                 availability = listOf(availability1, availability2),
                 preference = Preference.MONEY,
-                location = Location(51.5074, -0.1278, "London")
+                location = GeoPoint(51.5074, -0.1278)
             )
 
         repo.addUser(user1)
         repo.addUser(user2)
 
-        // delete user 1
         repo.deleteUser(user1.uid)
 
-        // get user 1 should throw an exception
         assertThrows(Exception::class.java) { runBlocking { repo.getUser(user1.uid) } }
-
-        // get user 2 should work
         assertEquals(user2, repo.getUser(user2.uid))
     }
 
     @Test
     fun editUserLocation() = runBlocking {
         val uid = repo.getNewUid()
-        val initialLocation = Location(46.5191, 6.5668, "EPFL")
+        val initialLocation = GeoPoint(46.5191, 6.5668)
         val user =
-            User(
+            createUser(
                 uid = uid,
                 username = "locationtester",
                 email = "location@test.com",
-                profilePicture = "",
-                skillSet = setOf(),
-                rating = 5.0f,
-                availability = listOf(),
-                preference = Preference.SKILLS,
                 location = initialLocation
             )
 
         repo.addUser(user)
         assertEquals(initialLocation, repo.getUser(uid).location)
 
-        val newLocation = Location(48.8566, 2.3522, "Paris, France")
+        val newLocation = GeoPoint(48.8566, 2.3522)
         val updatedUser = user.copy(location = newLocation)
 
         repo.editUser(uid, updatedUser)
@@ -273,23 +235,17 @@ class UserFireStoreTest {
 
         assertEquals(newLocation.latitude, retrievedUser.location.latitude, 0.0001)
         assertEquals(newLocation.longitude, retrievedUser.location.longitude, 0.0001)
-        assertEquals(newLocation.name, retrievedUser.location.name)
     }
 
     @Test
     fun editUserPreference() = runBlocking {
         val uid = repo.getNewUid()
         val user =
-            User(
+            createUser(
                 uid = uid,
                 username = "preferencetester",
                 email = "preference@test.com",
-                profilePicture = "",
-                skillSet = setOf(),
-                rating = 5.0f,
-                availability = listOf(),
-                preference = Preference.SKILLS,
-                location = Location(0.0, 0.0, "test")
+                location = GeoPoint(0.0, 0.0)
             )
 
         repo.addUser(user)
@@ -305,30 +261,21 @@ class UserFireStoreTest {
     fun testMultipleLocationsWithDifferentCoordinates() = runBlocking {
         val uid1 = repo.getNewUid()
         val user1 =
-            User(
+            createUser(
                 uid = uid1,
                 username = "user1",
                 email = "user1@test.com",
-                profilePicture = "",
-                skillSet = setOf(),
-                rating = 5.0f,
-                availability = listOf(),
-                preference = Preference.SKILLS,
-                location = Location(46.5191, 6.5668, "EPFL, Switzerland")
+                location = GeoPoint(46.5191, 6.5668)
             )
 
         val uid2 = repo.getNewUid()
         val user2 =
-            User(
+            createUser(
                 uid = uid2,
                 username = "user2",
                 email = "user2@test.com",
-                profilePicture = "",
-                skillSet = setOf(),
-                rating = 5.0f,
-                availability = listOf(),
                 preference = Preference.MONEY,
-                location = Location(35.6762, 139.6503, "Tokyo, Japan")
+                location = GeoPoint(35.6762, 139.6503)
             )
 
         repo.addUser(user1)
@@ -346,30 +293,22 @@ class UserFireStoreTest {
     fun testBothPreferenceValues() = runBlocking {
         val uid1 = repo.getNewUid()
         val userWithSkillsPreference =
-            User(
+            createUser(
                 uid = uid1,
                 username = "skillsuser",
                 email = "skills@test.com",
-                profilePicture = "",
-                skillSet = setOf(),
-                rating = 5.0f,
-                availability = listOf(),
                 preference = Preference.SKILLS,
-                location = Location(0.0, 0.0, "test")
+                location = GeoPoint(0.0, 0.0)
             )
 
         val uid2 = repo.getNewUid()
         val userWithMoneyPreference =
-            User(
+            createUser(
                 uid = uid2,
                 username = "moneyuser",
                 email = "money@test.com",
-                profilePicture = "",
-                skillSet = setOf(),
-                rating = 5.0f,
-                availability = listOf(),
                 preference = Preference.MONEY,
-                location = Location(0.0, 0.0, "test")
+                location = GeoPoint(0.0, 0.0)
             )
 
         repo.addUser(userWithSkillsPreference)

--- a/app/src/androidTest/java/com/swent/skillswap/model/post/PostFirestoreRepositoryTest.kt
+++ b/app/src/androidTest/java/com/swent/skillswap/model/post/PostFirestoreRepositoryTest.kt
@@ -2,7 +2,7 @@ package com.swent.skillswap.model.post
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.tags.PostTag
 import com.swent.skillswap.utils.FirebaseEmulator
 import java.util.Date
@@ -20,9 +20,9 @@ class PostRepositoryInstrumentedTest {
 
     private lateinit var repo: PostRepository
 
-    private val epflLocation = Location(46.5191, 6.5668, "EPFL, Switzerland")
-    private val lausanneLocation = Location(46.5197, 6.6323, "Lausanne, Switzerland")
-    private val genevaLocation = Location(46.2044, 6.1432, "Geneva, Switzerland")
+    private val epflLocation = GeoPoint(46.5191, 6.5668)
+    private val lausanneLocation = GeoPoint(46.5197, 6.6323)
+    private val genevaLocation = GeoPoint(46.2044, 6.1432)
 
     private val request1 =
         Request(
@@ -74,7 +74,7 @@ class PostRepositoryInstrumentedTest {
             assertEquals(PostType.REQUEST, fetched.type)
             assertEquals(req.location.latitude, fetched.location.latitude, 0.0001)
             assertEquals(req.location.longitude, fetched.location.longitude, 0.0001)
-            assertEquals(req.location.name, fetched.location.name)
+            assertEquals(req.location, fetched.location)
         }
     }
 

--- a/app/src/androidTest/java/com/swent/skillswap/ui/post/RequestScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/skillswap/ui/post/RequestScreenTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.post.*
 import com.swent.skillswap.model.tags.PostTag
 import com.swent.skillswap.model.tags.SkillTag
@@ -29,7 +29,7 @@ class RequestScreenTest {
     private var backButtonClicked = false
     private var postCreatedCalled = false
 
-    private val defaultLocation = Location(46.5191, 6.5668, "EPFL, Switzerland")
+    private val defaultLocation = GeoPoint(46.5191, 6.5668)
 
     private val sampleRequest =
         Request(

--- a/app/src/main/java/com/swent/skillswap/model/map/Location.kt
+++ b/app/src/main/java/com/swent/skillswap/model/map/Location.kt
@@ -1,7 +1,0 @@
-package com.swent.skillswap.model.map
-
-data class Location(
-    val latitude: Double,
-    val longitude: Double,
-    val name: String,
-)

--- a/app/src/main/java/com/swent/skillswap/model/post/FakePostRepository.kt
+++ b/app/src/main/java/com/swent/skillswap/model/post/FakePostRepository.kt
@@ -1,6 +1,6 @@
 package com.swent.skillswap.model.post
 
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.tags.EveryTag
 import com.swent.skillswap.model.user.calculateDistance
 import kotlinx.coroutines.delay
@@ -59,7 +59,7 @@ class FakePostRepository : PostRepository {
         paymentMethod: PaymentMethod,
         tags: Set<EveryTag>,
         status: PostStatus?,
-        userLocation: Location?,
+        userLocation: GeoPoint?,
         maxDistanceKm: Double?
     ): List<Post> {
         var filteredPosts =

--- a/app/src/main/java/com/swent/skillswap/model/post/Offer.kt
+++ b/app/src/main/java/com/swent/skillswap/model/post/Offer.kt
@@ -2,7 +2,7 @@
 package com.swent.skillswap.model.post
 
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.tags.EveryTag
 
 data class Offer(
@@ -16,7 +16,7 @@ data class Offer(
     override val creation: Timestamp,
     override val status: PostStatus,
     override val media: List<String>,
-    override val location: Location
+    override val location: GeoPoint
 ) : Post {
     override val type: PostType = PostType.OFFER
 }

--- a/app/src/main/java/com/swent/skillswap/model/post/Post.kt
+++ b/app/src/main/java/com/swent/skillswap/model/post/Post.kt
@@ -11,7 +11,7 @@
 package com.swent.skillswap.model.post
 
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.tags.EveryTag
 
 /**
@@ -42,7 +42,7 @@ interface Post {
     /** The type of the post, indicating whether it's an offer or a request. */
     val type: PostType
     /** The meeting location of the post */
-    val location: Location
+    val location: GeoPoint
     /**
      * A list of normalized search keywords used to support Firestore queries with
      * `whereArrayContainsAny`.

--- a/app/src/main/java/com/swent/skillswap/model/post/PostFirestoreRepository.kt
+++ b/app/src/main/java/com/swent/skillswap/model/post/PostFirestoreRepository.kt
@@ -8,11 +8,11 @@ package com.swent.skillswap.model.post
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.firestore.Query
 import com.google.firebase.firestore.SetOptions
 import com.swent.skillswap.firebase.FirestorePaths
 import com.swent.skillswap.firebase.FirestoreSettings
-import com.swent.skillswap.model.map.Location
 import com.swent.skillswap.model.tags.EveryTag
 import com.swent.skillswap.model.user.calculateDistance
 import kotlinx.coroutines.tasks.await
@@ -34,7 +34,7 @@ class PostFirestoreRepository(db: FirebaseFirestore) : PostRepository {
         paymentMethod: PaymentMethod,
         tags: Set<EveryTag>,
         status: PostStatus?,
-        userLocation: Location?,
+        userLocation: GeoPoint?,
         maxDistanceKm: Double?
     ): List<Post> {
         val query: Query =
@@ -151,13 +151,7 @@ class PostFirestoreRepository(db: FirebaseFirestore) : PostRepository {
 
         val postType = document.getString("type")?.let { PostType.valueOf(it) }!!
 
-        val locationMap = document.get("location") as? Map<*, *>
-        val location =
-            Location(
-                latitude = locationMap?.get("latitude") as? Double ?: 0.0,
-                longitude = locationMap?.get("longitude") as? Double ?: 0.0,
-                name = locationMap?.get("name") as? String ?: ""
-            )
+        val location = document.getGeoPoint("location")!!
 
         val post =
             when (postType) {
@@ -189,26 +183,20 @@ class PostFirestoreRepository(db: FirebaseFirestore) : PostRepository {
         }
     }
 
-    private fun serializePost(post: Post): Map<String, Any> {
-        return mapOf(
-            "uid" to post.uid,
-            "title" to post.title,
-            "description" to post.description,
-            "ownerId" to post.ownerId,
-            "tags" to post.tags.map { it.toString() },
-            "paymentMethod" to post.paymentMethod.name,
-            "expiry" to post.expiry,
-            "creation" to post.creation,
-            "status" to post.status.name,
-            "media" to post.media,
-            "type" to post.type.name,
-            "location" to
-                mapOf( // Store as nested map instead of JSON string
-                    "latitude" to post.location.latitude,
-                    "longitude" to post.location.longitude,
-                    "name" to post.location.name
-                ),
-            "searchKeys" to buildSearchKeys(post.title, post.tags as Set<EveryTag>)
+    private fun serializePost(post: Post): SerializablePost {
+        return SerializablePost(
+            uid = post.uid,
+            title = post.title,
+            description = post.description,
+            ownerId = post.ownerId,
+            tags = post.tags.toList(),
+            paymentMethod = post.paymentMethod,
+            expiry = post.expiry,
+            creation = post.creation,
+            status = post.status,
+            media = post.media,
+            type = post.type,
+            location = post.location
         )
     }
 }

--- a/app/src/main/java/com/swent/skillswap/model/post/PostRepository.kt
+++ b/app/src/main/java/com/swent/skillswap/model/post/PostRepository.kt
@@ -7,7 +7,7 @@
  */
 package com.swent.skillswap.model.post
 
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.tags.EveryTag
 
 /**
@@ -47,7 +47,7 @@ interface PostRepository {
         paymentMethod: PaymentMethod = PaymentMethod.SKILLSANDCASH,
         tags: Set<EveryTag> = emptySet(),
         status: PostStatus? = null,
-        userLocation: Location? = null,
+        userLocation: GeoPoint? = null,
         maxDistanceKm: Double? = null
     ): List<Post>
 

--- a/app/src/main/java/com/swent/skillswap/model/post/Request.kt
+++ b/app/src/main/java/com/swent/skillswap/model/post/Request.kt
@@ -2,7 +2,7 @@
 package com.swent.skillswap.model.post
 
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.tags.EveryTag
 
 data class Request(
@@ -16,7 +16,7 @@ data class Request(
     override val creation: Timestamp,
     override val status: PostStatus,
     override val media: List<String>,
-    override val location: Location
+    override val location: GeoPoint
 ) : Post {
     override val type: PostType
         get() = PostType.REQUEST

--- a/app/src/main/java/com/swent/skillswap/model/post/SerializablePost.kt
+++ b/app/src/main/java/com/swent/skillswap/model/post/SerializablePost.kt
@@ -1,7 +1,7 @@
 package com.swent.skillswap.model.post
 
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.tags.EveryTag
 import java.io.Serializable
 
@@ -17,5 +17,5 @@ data class SerializablePost(
     override val status: PostStatus,
     override val media: List<String>,
     override val type: PostType,
-    override val location: Location
+    override val location: GeoPoint
 ) : Post, Serializable

--- a/app/src/main/java/com/swent/skillswap/model/user/User.kt
+++ b/app/src/main/java/com/swent/skillswap/model/user/User.kt
@@ -1,6 +1,6 @@
 package com.swent.skillswap.model.user
 
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import java.time.DayOfWeek
 import java.time.LocalTime
 
@@ -19,12 +19,7 @@ data class User(
     val rating: Float = 0f,
     val availability: List<Availability> = emptyList(),
     val preference: Preference = Preference.SKILLS,
-    val location: Location =
-        Location(
-            46.5191,
-            6.5668,
-            "École Polytechnique Fédérale de Lausanne (EPFL), Switzerland"
-        ) // Default location
+    val location: GeoPoint = GeoPoint(46.5191, 6.5668) // EPFL default location
     // val offerSet: Set<Offer>,
     // val favoriteOffers: Set<Offer>
 )

--- a/app/src/main/java/com/swent/skillswap/model/user/UserRepoFirestore.kt
+++ b/app/src/main/java/com/swent/skillswap/model/user/UserRepoFirestore.kt
@@ -9,6 +9,7 @@ package com.swent.skillswap.model.user
 
 import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.firestore.SetOptions
 import com.swent.skillswap.firebase.FirestorePaths.USERS_COLLECTION
 import kotlinx.coroutines.tasks.await
@@ -33,7 +34,7 @@ class UserRepoFirestore(private val db: FirebaseFirestore) : UserRepositery {
                 rating = (data["rating"] as? Number)?.toFloat() ?: 0f,
                 availability = deserializeAvailabilities(data["availability"] as String),
                 preference = deserializePreference(data["preference"] as String),
-                location = deserializeLocation(data["location"] as String)
+                location = data["location"] as GeoPoint
             )
         } catch (e: Exception) {
             Log.e("UserRepoFirestore", "Error while getting user in getUser", e)
@@ -51,7 +52,7 @@ class UserRepoFirestore(private val db: FirebaseFirestore) : UserRepositery {
                 "rating" to user.rating,
                 "availability" to serializeAvailabilities(user.availability),
                 "preference" to serializePreference(user.preference),
-                "location" to serializeLocation(user.location)
+                "location" to user.location
             )
 
         db.collection(USERS_COLLECTION).document(user.uid).set(userData)
@@ -76,7 +77,7 @@ class UserRepoFirestore(private val db: FirebaseFirestore) : UserRepositery {
                     "rating" to newValue.rating,
                     "availability" to serializeAvailabilities(newValue.availability),
                     "preference" to serializePreference(newValue.preference),
-                    "location" to serializeLocation(newValue.location)
+                    "location" to newValue.location
                 ),
                 SetOptions.merge()
             )

--- a/app/src/main/java/com/swent/skillswap/model/user/UserUtils.kt
+++ b/app/src/main/java/com/swent/skillswap/model/user/UserUtils.kt
@@ -8,7 +8,7 @@
 package com.swent.skillswap.model.user
 
 import android.annotation.SuppressLint
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.tags.SkillTag
 import java.time.DayOfWeek
 import java.time.LocalTime
@@ -40,17 +40,6 @@ data class SerializableAvailability(
     val day: String = "",
     val startTime: String = "",
     val endTime: String = ""
-)
-
-/*
- * Serializable version of Location class to convert to/from JSON automatically with kotlinx.serialization
- */
-@SuppressLint("UnsafeOptInUsageError")
-@Serializable
-data class SerializableLocation(
-    val latitude: Double = 0.0,
-    val longitude: Double = 0.0,
-    val name: String = ""
 )
 
 /* HELPER FUNCTIONS */
@@ -122,17 +111,7 @@ fun deserializePreference(preference: String): Preference {
     return Preference.valueOf(preference)
 }
 
-fun serializeLocation(location: Location): String {
-    val serialized = SerializableLocation(location.latitude, location.longitude, location.name)
-    return Json.encodeToString(serialized)
-}
-
-fun deserializeLocation(location: String): Location {
-    val deserialized = Json.decodeFromString<SerializableLocation>(location)
-    return Location(deserialized.latitude, deserialized.longitude, deserialized.name)
-}
-
-fun calculateDistance(loc1: Location, loc2: Location): Double {
+fun calculateDistance(loc1: GeoPoint, loc2: GeoPoint): Double {
 
     val earthRadiusKm = 6371.0
 

--- a/app/src/main/java/com/swent/skillswap/ui/chat/ChatScreenData.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/chat/ChatScreenData.kt
@@ -5,7 +5,7 @@
 package com.swent.skillswap.ui.chat
 
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.post.Offer
 import com.swent.skillswap.model.post.PaymentMethod
 import com.swent.skillswap.model.post.Post
@@ -17,8 +17,7 @@ import com.swent.skillswap.model.user.User
 /** Sample data provider for chat screen demonstration */
 object ChatScreenData {
 
-    private val defaultLocation =
-        Location(46.5191, 6.5668, "École Polytechnique Fédérale de Lausanne (EPFL), Switzerland")
+    private val defaultLocation = GeoPoint(46.5191, 6.5668)
 
     fun getSampleUsers(): Map<String, User> {
         return mapOf(

--- a/app/src/main/java/com/swent/skillswap/ui/post/RequestScreen.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/post/RequestScreen.kt
@@ -52,8 +52,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.firebase.FirestoreSettings.MAX_SEARCH_KEYS
-import com.swent.skillswap.model.map.Location
 import com.swent.skillswap.model.post.PaymentMethod
 import com.swent.skillswap.model.post.PostRepository
 import com.swent.skillswap.model.tags.SkillTag
@@ -357,7 +357,7 @@ fun NewRequestScreenPreview() {
                 paymentMethod: PaymentMethod,
                 tags: Set<com.swent.skillswap.model.tags.EveryTag>,
                 status: com.swent.skillswap.model.post.PostStatus?,
-                userLocation: Location?,
+                userLocation: GeoPoint?,
                 maxDistanceKm: Double?
             ): List<com.swent.skillswap.model.post.Post> = emptyList()
 

--- a/app/src/main/java/com/swent/skillswap/ui/post/RequestViewModel.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/post/RequestViewModel.kt
@@ -3,7 +3,7 @@ package com.swent.skillswap.ui.post
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.post.PaymentMethod
 import com.swent.skillswap.model.post.PostRepository
 import com.swent.skillswap.model.post.PostStatus
@@ -34,7 +34,7 @@ data class RequestUIState(
     val tags: Set<EveryTag> = emptySet(),
     val paymentMethod: PaymentMethod = PaymentMethod.SKILLS,
     val expiry: Timestamp = Timestamp.now(),
-    val location: Location = Location(46.5191, 6.5668, "EPFL, Switzerland"), // Default fallback
+    val location: GeoPoint = GeoPoint(46.5191, 6.5668), // Default fallback
 
     // Error fields
     val titleError: String = "",
@@ -135,7 +135,7 @@ class RequestViewModel(
         _uiState.update { current -> current.copy(paymentMethod = methodClicked) }
     }
 
-    fun setLocation(newLocation: Location) {
+    fun setLocation(newLocation: GeoPoint) {
         _uiState.update { it.copy(location = newLocation) }
     }
 

--- a/app/src/main/java/com/swent/skillswap/viewModel/ProfileViewModel.kt
+++ b/app/src/main/java/com/swent/skillswap/viewModel/ProfileViewModel.kt
@@ -6,8 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.ktx.Firebase
-import com.swent.skillswap.model.map.Location
 import com.swent.skillswap.model.user.Availability
 import com.swent.skillswap.model.user.Preference
 import com.swent.skillswap.model.user.Skill
@@ -89,7 +89,7 @@ class ProfileViewModel(
         rating: Float? = null,
         availability: List<Availability>? = null,
         preference: Preference? = null,
-        location: Location? = null
+        location: GeoPoint? = null
     ) {
         val current = _userState.value
         val uid = current.uid.ifEmpty { FirebaseAuth.getInstance().currentUser?.uid }

--- a/app/src/test/java/com/swent/skillswap/LocationDistanceUnitTest.kt
+++ b/app/src/test/java/com/swent/skillswap/LocationDistanceUnitTest.kt
@@ -1,6 +1,6 @@
 package com.swent.skillswap
 
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.user.calculateDistance
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -14,7 +14,7 @@ class LocationDistanceUnitTest {
 
     @Test
     fun calculateDistance_sameLocation_returnsZero() {
-        val epfl = Location(46.5191, 6.5668, "EPFL")
+        val epfl = GeoPoint(46.5191, 6.5668)
 
         val distance = calculateDistance(epfl, epfl)
 
@@ -23,8 +23,8 @@ class LocationDistanceUnitTest {
 
     @Test
     fun calculateDistance_slightlyDifferentLocation_returnsSmallDistance() {
-        val epfl = Location(46.5191, 6.5668, "EPFL")
-        val nearby = Location(46.5195, 6.5672, "Nearby")
+        val epfl = GeoPoint(46.5191, 6.5668)
+        val nearby = GeoPoint(46.5195, 6.5672)
 
         val distance = calculateDistance(epfl, nearby)
 
@@ -35,8 +35,8 @@ class LocationDistanceUnitTest {
 
     @Test
     fun calculateDistance_parisToLondon_returnsCorrectDistance() {
-        val paris = Location(48.8566, 2.3522, "Paris")
-        val london = Location(51.5074, -0.1278, "London")
+        val paris = GeoPoint(48.8566, 2.3522)
+        val london = GeoPoint(51.5074, -0.1278)
 
         val distance = calculateDistance(paris, london)
 
@@ -46,8 +46,8 @@ class LocationDistanceUnitTest {
 
     @Test
     fun calculateDistance_newYorkToLosAngeles_returnsCorrectDistance() {
-        val newYork = Location(40.7128, -74.0060, "New York")
-        val losAngeles = Location(34.0522, -118.2437, "Los Angeles")
+        val newYork = GeoPoint(40.7128, -74.0060)
+        val losAngeles = GeoPoint(34.0522, -118.2437)
 
         val distance = calculateDistance(newYork, losAngeles)
 
@@ -57,8 +57,8 @@ class LocationDistanceUnitTest {
 
     @Test
     fun calculateDistance_acrossEquator_returnsCorrectDistance() {
-        val northernPoint = Location(10.0, 0.0, "North")
-        val southernPoint = Location(-10.0, 0.0, "South")
+        val northernPoint = GeoPoint(10.0, 0.0)
+        val southernPoint = GeoPoint(-10.0, 0.0)
 
         val distance = calculateDistance(northernPoint, southernPoint)
 
@@ -68,8 +68,8 @@ class LocationDistanceUnitTest {
 
     @Test
     fun calculateDistance_acrossPrimeMeridian_returnsCorrectDistance() {
-        val western = Location(0.0, -10.0, "West")
-        val eastern = Location(0.0, 10.0, "East")
+        val western = GeoPoint(0.0, -10.0)
+        val eastern = GeoPoint(0.0, 10.0)
 
         val distance = calculateDistance(western, eastern)
 
@@ -79,8 +79,8 @@ class LocationDistanceUnitTest {
 
     @Test
     fun calculateDistance_acrossDateLine_returnsCorrectDistance() {
-        val western = Location(0.0, 179.0, "West of Date Line")
-        val eastern = Location(0.0, -179.0, "East of Date Line")
+        val western = GeoPoint(0.0, 179.0)
+        val eastern = GeoPoint(0.0, -179.0)
 
         val distance = calculateDistance(western, eastern)
 
@@ -90,8 +90,8 @@ class LocationDistanceUnitTest {
 
     @Test
     fun calculateDistance_symmetry_returnsEqualDistance() {
-        val loc1 = Location(46.5191, 6.5668, "EPFL")
-        val loc2 = Location(47.3769, 8.5417, "Zurich")
+        val loc1 = GeoPoint(46.5191, 6.5668)
+        val loc2 = GeoPoint(47.3769, 8.5417)
 
         val distance1 = calculateDistance(loc1, loc2)
         val distance2 = calculateDistance(loc2, loc1)
@@ -102,8 +102,8 @@ class LocationDistanceUnitTest {
 
     @Test
     fun calculateDistance_northPole_returnsCorrectDistance() {
-        val northPole = Location(90.0, 0.0, "North Pole")
-        val equator = Location(0.0, 0.0, "Equator")
+        val northPole = GeoPoint(90.0, 0.0)
+        val equator = GeoPoint(0.0, 0.0)
 
         val distance = calculateDistance(northPole, equator)
 
@@ -113,8 +113,8 @@ class LocationDistanceUnitTest {
 
     @Test
     fun calculateDistance_southPole_returnsCorrectDistance() {
-        val southPole = Location(-90.0, 0.0, "South Pole")
-        val equator = Location(0.0, 0.0, "Equator")
+        val southPole = GeoPoint(-90.0, 0.0)
+        val equator = GeoPoint(0.0, 0.0)
 
         val distance = calculateDistance(southPole, equator)
 
@@ -124,8 +124,8 @@ class LocationDistanceUnitTest {
 
     @Test
     fun calculateDistance_antipodes_returnsMaxDistance() {
-        val point1 = Location(40.7128, -74.0060, "New York")
-        val point2 = Location(-40.7128, 105.9940, "Antipode")
+        val point1 = GeoPoint(40.7128, -74.0060)
+        val point2 = GeoPoint(-40.7128, 105.9940)
 
         val distance = calculateDistance(point1, point2)
 

--- a/app/src/test/java/com/swent/skillswap/post/PostDataClassTest.kt
+++ b/app/src/test/java/com/swent/skillswap/post/PostDataClassTest.kt
@@ -1,7 +1,7 @@
 package com.swent.skillswap.post
 
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.post.PaymentMethod
 import com.swent.skillswap.model.post.PostStatus
 import com.swent.skillswap.model.post.PostType
@@ -18,7 +18,7 @@ import org.junit.Test
 
 class PostDataClassTest {
 
-    private val testLocation = Location(latitude = 46.5191, longitude = 6.5668, name = "EPFL")
+    private val testLocation = GeoPoint(46.5191, 6.5668)
 
     val request1 =
         Request(

--- a/app/src/test/java/com/swent/skillswap/post/RequestViewModelTest.kt
+++ b/app/src/test/java/com/swent/skillswap/post/RequestViewModelTest.kt
@@ -3,7 +3,7 @@
 package com.swent.skillswap.post
 
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.post.*
 import com.swent.skillswap.model.tags.PostTag
 import com.swent.skillswap.ui.post.PostOperation
@@ -28,7 +28,7 @@ class RequestViewModelTest {
     private lateinit var viewModel: RequestViewModel
     private val testUserId = "test-user-123"
 
-    private val testLocation = Location(latitude = 46.5191, longitude = 6.5668, name = "EPFL")
+    private val testLocation = GeoPoint(46.5191, 6.5668)
 
     // Test fixture
     private val sampleRequest =

--- a/app/src/test/java/com/swent/skillswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/test/java/com/swent/skillswap/ui/chat/ChatScreenTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.post.Offer
 import com.swent.skillswap.model.post.PaymentMethod
 import com.swent.skillswap.model.post.Post
@@ -30,7 +30,7 @@ class ChatScreenTest {
 
     private fun pastTs() = Timestamp(now() - 10, 0)
 
-    private val testLocation = Location(latitude = 46.5191, longitude = 6.5668, name = "EPFL")
+    private val testLocation = GeoPoint(46.5191, 6.5668)
 
     private fun samplePosts(): List<Post> =
         listOf(

--- a/app/src/test/java/com/swent/skillswap/ui/chat/PostConversationItemTest.kt
+++ b/app/src/test/java/com/swent/skillswap/ui/chat/PostConversationItemTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.Timestamp
-import com.swent.skillswap.model.map.Location
+import com.google.firebase.firestore.GeoPoint
 import com.swent.skillswap.model.post.Offer
 import com.swent.skillswap.model.post.PaymentMethod
 import com.swent.skillswap.model.post.PostStatus
@@ -20,7 +20,7 @@ class PostConversationItemTest {
 
     @get:Rule val composeRule = createComposeRule()
 
-    private val testLocation = Location(latitude = 46.5191, longitude = 6.5668, name = "EPFL")
+    private val testLocation = GeoPoint(46.5191, 6.5668)
 
     private fun offer(): Offer =
         Offer(


### PR DESCRIPTION
feat(post): Add location field to Post model and fix search keys serialization

## Problem
The Post model needed to support location-based filtering, but adding the 
location field broke the existing search functionality. The search keys were 
not being properly serialized to Firestore after migrating from the 
SerializablePost data class approach to a Map<String, Any> serialization 
strategy.

## Root Cause
In the previous implementation, searchKeys were automatically serialized 
when using SerializablePost (which implemented the Post interface). The 
computed property `searchKeys` was evaluated by Firestore's automatic 
serialization. After switching to manual Map serialization to accommodate 
the new location field, the searchKeys were inadvertently excluded from 
the serialization map, causing whereArrayContainsAny queries to fail.

## Changes Made

### 1. Added Location Support
- Added `location` field to Post interface containing:
  - latitude: Double
  - longitude: Double  
  - name: String
- Updated serializePost() to serialize location as a nested map
- Updated documentToPost() to deserialize location data

### 2. Fixed Search Keys Serialization
- Added `searchKeys` to the serializePost() map output
- The searchKeys are computed from the Post interface's getter property
- This ensures the array is stored in Firestore for query filtering

### 3. Search Keys Implementation Details
The searchKeys system enables case-insensitive, multi-field searching by:
- Splitting title into lowercase words
- Converting tags to lowercase strings
- Storing these tokens in a Firestore array field
- Using whereArrayContainsAny() for flexible matching

Closes #114 
