### PR TITLE
fix(ui-auth): fix bottom bar bug

### DIFF
--- a/app/src/main/java/com/swent/skillswap/MainActivity.kt
+++ b/app/src/main/java/com/swent/skillswap/MainActivity.kt
@@ -89,8 +89,8 @@ fun SkillSwapApp(navController: NavHostController = rememberNavController()) {
     val navBackStackEntry = navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry.value?.destination?.route
 
-    val editProfileViewModel = remember { EditUserViewModel() }
-    val bottomBarViewModel = remember { BottomBarViewModel() }
+    val editProfileViewModel: EditUserViewModel = viewModel()
+    val bottomBarViewModel: BottomBarViewModel = viewModel()
 
     val isTopLevel = screens.firstOrNull { it.route == currentRoute }?.isTopLevelDestination == true
 

--- a/app/src/main/java/com/swent/skillswap/ui/navigation/bottomBar/BottomBar.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/navigation/bottomBar/BottomBar.kt
@@ -66,7 +66,7 @@ fun BottomBar(
     onOfferClick: () -> Unit = {},
     onChatClick: () -> Unit = {},
 ) {
-    val state by vm.uiState.collectAsState(initial = BottomBarUiState())
+    val state by vm.uiState.collectAsState()
 
     // Collect one-time navigation events and delegate to the appropriate lambda
     LaunchedEffect(Unit) {


### PR DESCRIPTION
**Summary**
from what I can gather everythink that is pack in `remember {}` does not survive relaunch of main activity the only ones that do is the viewModel create with the `viewModel()` function with correct casting so please do remember that for next time. So in this fix I just make correct use of `viewModel()` so now bottomBar does not loose his state.
close issue #199 

*Note:*
if you do not understand my statement note that changing theme relaunch mainActivity and also if the app is for a too long time in backround to economise energy.