### PR TITLE
chore: add firebase logs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 .externalNativeBuild
 .cxx
 local.properties
+/firebase-debug.log
+/firestore-debug.log


### PR DESCRIPTION
Small PR that adds the firebase and firestore log files to gitignore.

Closes #263 