### PR TITLE
refactor: extract error message constants in FakeUserRepository

### DIFF
--- a/app/src/test/java/com/swent/skillswap/model/user/FakeUserRepository.kt
+++ b/app/src/test/java/com/swent/skillswap/model/user/FakeUserRepository.kt
@@ -8,6 +8,13 @@ import kotlinx.coroutines.delay
  * testing success/failure cases without actual database interactions.
  */
 class FakeUserRepository : UserRepositery {
+    companion object {
+        private const val ERROR_GET_FAILURE = "Simulated get failure"
+        private const val ERROR_ADD_FAILURE = "Simulated add failure"
+        private const val ERROR_EDIT_FAILURE = "Simulated edit failure"
+        private const val ERROR_UPDATE_FCM_TOKEN_FAILURE = "Simulated updateFcmToken failure"
+    }
+
     private val users = mutableMapOf<String, User>()
     private var uidCounter = 0
     private var shouldFailOnAdd = false
@@ -50,7 +57,7 @@ class FakeUserRepository : UserRepositery {
             delay(delayMillis)
         }
         if (shouldFailOnGet) {
-            throw Exception("Simulated get failure")
+            throw Exception(ERROR_GET_FAILURE)
         }
         return users[userID] ?: throw Exception("User not found: $userID")
     }
@@ -60,7 +67,7 @@ class FakeUserRepository : UserRepositery {
             delay(delayMillis)
         }
         if (shouldFailOnAdd) {
-            throw Exception("Simulated add failure")
+            throw Exception(ERROR_ADD_FAILURE)
         }
         users[user.uid] = user
     }
@@ -70,7 +77,7 @@ class FakeUserRepository : UserRepositery {
             delay(delayMillis)
         }
         if (shouldFailOnEdit) {
-            throw Exception("Simulated edit failure")
+            throw Exception(ERROR_EDIT_FAILURE)
         }
         if (!users.containsKey(userID)) {
             throw Exception("Cannot edit non-existent user: $userID")
@@ -91,7 +98,7 @@ class FakeUserRepository : UserRepositery {
             delay(delayMillis)
         }
         if (shouldFailOnUpdateFcmToken) {
-            throw Exception("Simulated updateFcmToken failure")
+            throw Exception(ERROR_UPDATE_FCM_TOKEN_FAILURE)
         }
         val user = users[userId] ?: throw Exception("User not found: $userId")
         users[userId] = user.copy(fcmToken = fcmToken)


### PR DESCRIPTION
## Description

This PR addresses a code quality issue in `FakeUserRepository` where error message string literals were duplicated across multiple methods.

## Changes

- Extracted 4 duplicated error message strings into constants in a `companion object`
- Replaced all string literals with the corresponding constants:
  - `ERROR_GET_FAILURE`
  - `ERROR_ADD_FAILURE`
  - `ERROR_EDIT_FAILURE`
  - `ERROR_UPDATE_FCM_TOKEN_FAILURE`

## Benefits

- **Maintainability**: Error messages are now defined in a single location
- **Consistency**: Prevents typos and ensures uniform error messages
- **Code quality**: Follows best practices for avoiding magic strings

## Testing

- Code compiles successfully
- All existing tests continue to pass
- No functional changes, only refactoring

The PR description is made with AI