### PR TITLE
fix(AddPost) wire location to adding post

### DIFF
--- a/app/src/main/java/com/swent/skillswap/ui/post/RequestViewModel.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/post/RequestViewModel.kt
@@ -205,7 +205,7 @@ class RequestViewModel(
                         creation = Timestamp.now(),
                         status = PostStatus.POSTED,
                         media = emptyList(), // TODO: upload attachments to db and store links
-                        location = uiState.value.location
+                        location = _uiState.value.location
                     )
 
                 // Will call validate() internally


### PR DESCRIPTION
This PR connects the location system to the Add Post screen so new requests automatically include the user’s current geopoint.

### **What’s included**
- Inject current location during `PostOperation.ADD`
- Retrieve location via `LocationManager.getCurrentLocationSync()`
- Initialize new `Request` objects with the retrieved geopoint

### **Why**
Location was not previously set when creating a new post, which limited location-based features.

### **Testing**
1. Create a new request
2. Confirm the location field is automatically populated
3. Verify editing an existing post does not modify its location

Closes #346 