### PR TITLE
fix(issue-#386): fixed issue

### DIFF
--- a/app/src/main/java/com/swent/skillswap/MainActivity.kt
+++ b/app/src/main/java/com/swent/skillswap/MainActivity.kt
@@ -174,7 +174,7 @@ fun SkillSwapApp(
 
     var controller by remember { mutableStateOf<FeedController?>(null) }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(Firebase.auth.uid) {
         val recommendationEngine =
             RecommendationEngineFactory(UserRepoFirestore(Firebase.firestore))
                 .create(


### PR DESCRIPTION
**Summary**
so the issue was there because the uid of the login user was never updated while on the app so changed the launchedEffect arg to trigger a recompose of the recommendationEngine and feedcontroller only on user login changes.

*Note*
~~not sure if I have addressed the correct issue since it seems to be to simple.~~