### PR TITLE
fix(chat): add launchedEffect to getChatsOfCurrentUser

### DIFF
--- a/app/src/main/java/com/swent/skillswap/ui/chat/ChatListScreen.kt
+++ b/app/src/main/java/com/swent/skillswap/ui/chat/ChatListScreen.kt
@@ -48,7 +48,9 @@ fun ChatListScreen(
     var isPendingSelected by remember { mutableStateOf(false) }
     var isOwnerSelected by remember { mutableStateOf<Boolean?>(null) }
     // Chat List
-    viewModel.getChatsOfCurrentUser(selectedPostType, isPendingSelected, isOwnerSelected)
+    LaunchedEffect(selectedPostType, isPendingSelected, isOwnerSelected) {
+        viewModel.getChatsOfCurrentUser(selectedPostType, isPendingSelected, isOwnerSelected)
+    }
     Column(modifier = Modifier.fillMaxSize().padding(16.dp).testTag(ChatListTestTags.SCREEN)) {
         // Title
         Text(


### PR DESCRIPTION
This avoids network calls on screen recomposition.

For a full explanation of this issue, see #417