### PR TITLE
Change trigger branch from M1 to main

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -3,7 +3,7 @@ name: Build APK
 on:
   push:
     branches:
-      - M1
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration, changing the branch that triggers the APK build process from `M1` to `main`. This is for the final apk for M3